### PR TITLE
Breaking: Bump node-source-walk for Babylon support

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,3 @@
+{
+  "preset": "mrjoelkemp"
+}

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+test
+.gitignore
+.jscsrc
+.travis.yml

--- a/Readme.md
+++ b/Readme.md
@@ -4,7 +4,7 @@
 
 `npm install detective-cjs`
 
-But brah, substack already built this: node-detective. Yes, but I needed the capability to reuse an AST
+But dude, substack already built this: node-detective. Yes, but I needed the capability to reuse an AST
 and this was unlikely to be merged timely. I can also support jsx and other syntactic constructs faster.
 
 ### Usage
@@ -19,7 +19,7 @@ var dependencies = detective(mySourceCode);
 
 ```
 
-* Supports JSX and any other features that [node-source-walk](https://github.com/mrjoelkemp/node-source-walk) supports.
+* Supports JSX, ES7, and any other features that [node-source-walk](https://github.com/mrjoelkemp/node-source-walk) supports.
 
 #### License
 

--- a/index.js
+++ b/index.js
@@ -1,15 +1,12 @@
 var Walker = require('node-source-walk');
 var types = require('ast-module-types');
-var escodegen = require('escodegen');
 
 /**
  * @param  {String|Object} content - A file's string content or its AST
  * @return {String[]} The file's dependencies
  */
 module.exports = function(content) {
-  var walker = new Walker({
-    ecmaVersion: 6
-  });
+  var walker = new Walker();
 
   var dependencies = [];
 
@@ -22,14 +19,10 @@ module.exports = function(content) {
       return;
     }
 
-    if (node.arguments[0].type === 'Literal') {
+    if (node.arguments[0].type === 'Literal' || node.arguments[0].type === 'StringLiteral') {
       dependency = node.arguments[0].value;
-
-    } else {
-      dependency = escodegen.generate(node.arguments[0]);
+      dependencies.push(dependency);
     }
-
-    dependencies.push(dependency);
   });
 
   return dependencies;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Get the dependencies of a CommonJS module by traversing its AST",
   "main": "index.js",
   "scripts": {
-    "test": "jscs -p google index.js test && mocha test/test.js"
+    "test": "jscs index.js test && mocha test/test.js"
   },
   "repository": {
     "type": "git",
@@ -27,12 +27,12 @@
   "homepage": "https://github.com/mrjoelkemp/node-detective-cjs",
   "devDependencies": {
     "jscs": "~2.4.0",
+    "jscs-preset-mrjoelkemp": "~1.0.0",
     "mocha": "~2.0.1",
     "sinon": "~1.12.2"
   },
   "dependencies": {
-    "ast-module-types": "^2.2.1",
-    "escodegen": "^1.5.0",
-    "node-source-walk": "^2.0.0"
+    "ast-module-types": "^2.3.2",
+    "node-source-walk": "^3.0.0"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,6 @@
 var assert = require('assert');
 var detective = require('../');
 var sinon = require('sinon');
-var escodegen = require('escodegen');
 
 describe('detective-cjs', function() {
   var ast = {
@@ -52,16 +51,9 @@ describe('detective-cjs', function() {
     assert.equal(deps[0], './a');
   });
 
-  it('calls escodegen generate for non-literal require arguments (#1)', function() {
-    sinon.spy(escodegen, 'generate');
-    detective('var a = require("./foo" + "bar");');
-    assert.ok(escodegen.generate.called);
-    escodegen.generate.restore();
-  });
-
   it('does not throw on jsx', function() {
     assert.doesNotThrow(function() {
-      detective('var a = require("./foo" + "bar"); var templ = <jsx />');
+      detective('var a = require("./foobar"); var templ = <jsx />');
     });
   });
 });


### PR DESCRIPTION
- Drop escodegen for unlikely import scenario
