### PR TITLE
Support detecting template literal syntax in require statement

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,9 @@ module.exports = function(content) {
     if (node.arguments[0].type === 'Literal' || node.arguments[0].type === 'StringLiteral') {
       dependency = node.arguments[0].value;
       dependencies.push(dependency);
+    } else if (node.arguments[0].type === 'TemplateLiteral') {
+      dependency = node.arguments[0].quasis[0].value.raw;
+      dependencies.push(dependency);
     }
   });
 

--- a/test/test.js
+++ b/test/test.js
@@ -36,8 +36,8 @@ describe('detective-cjs', function() {
   });
 
   it('supports es6', function() {
-    var deps = detective('const a = require("./a");\n let b = require("./b");');
-    assert.equal(deps.length, 2);
+    var deps = detective('const a = require("./a");\n let b = require("./b");\n var c = require(`./c`);');
+    assert.equal(deps.length, 3);
   });
 
   it('returns an empty list if there are no dependencies', function() {


### PR DESCRIPTION
Close #5 

## Limitation
Only static template literals are detected, i.e. this would only detect dependencies where backticks and quotes can be used interchangeably in the require statement. For dynamic template literals, only the first static part is outputted, e.g. ``require(`hello-${world}-message`)`` would make `hello-` being added to dependencies.

This shouldn't be an issue unless someone decides to do the following (which is IMO very unlikely to happen):
```javascript
const orgName = `@myorg/`
const myDependency = require(`${orgName}my-dependency`)
```