### PR TITLE
Fixes regression in 3.1.0 where dynamic requires became broken

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,10 @@ module.exports = function(content) {
     }
 
     if (types.isPlainRequire(node)) {
-      dependencies.push(extractDependencyFromRequire(node));
+      const result = extractDependencyFromRequire(node);
+      if (result) {
+        dependencies.push(result);
+      }
     } else if (types.isMainScopedRequire(node)) {
       dependencies.push(extractDependencyFromMainRequire(node));
     }

--- a/test/test.js
+++ b/test/test.js
@@ -43,6 +43,13 @@ describe('detective-cjs', function() {
     assert.equal(deps.length, 2);
   });
 
+  it('does exclude requires based on variable values', function() {
+    const deps = detective('var a = require("./a");\n var b = "foo" + ".js";;\n var c = require(b);');
+
+    assert.equal(deps[0], './a');
+    assert.equal(deps.length, 1);
+  });
+
   it('returns an empty list if there are no dependencies', function() {
     const deps = detective('1 + 1;');
     assert.equal(deps.length, 0);


### PR DESCRIPTION
After updating to the latest version of detective-cjs (`3.1.0`) and [dependency-check](https://www.npmjs.com/package/dependency-check) my dependency checks started failing on one of my projects, throwing a weird error

Being a maintainer of `dependency-check` I decided to look into it and after some digging I found that it was a case of a dynamic require that can be summarized as:

```javascript
const moduleToLoad = 'foo';
const loadedModule = require(moduleToLoad);
```

I've added a fix for that in this PR 👍

Thanks for a nice module!