### PR TITLE
support `skipLazyLoaded` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const Walker = require('node-source-walk');
  * @param  {String|Object} content - A file's string content or its AST
  * @return {String[]} The file's dependencies
  */
-module.exports = function(content) {
+module.exports = function(content, options = {}) {
   const walker = new Walker();
   const dependencies = [];
 
@@ -17,9 +17,11 @@ module.exports = function(content) {
     }
 
     if (types.isPlainRequire(node)) {
-      const result = extractDependencyFromRequire(node);
-      if (result) {
-        dependencies.push(result);
+      if (!options.skipLazyLoaded || (options.skipLazyLoaded && types.isTopLevelRequire(node))) {
+        const result = extractDependencyFromRequire(node);
+        if (result) {
+          dependencies.push(result);
+        }
       }
     } else if (types.isMainScopedRequire(node)) {
       dependencies.push(extractDependencyFromMainRequire(node));

--- a/test/test.js
+++ b/test/test.js
@@ -70,6 +70,15 @@ describe('detective-cjs', () => {
     });
   });
 
+  it('skipLazyLoaded only counts top-level requires', () => {
+    const fnWithDynamicRequire = 'function foo() { const a = require("./a"); }';
+    const deps1 = detective(fnWithDynamicRequire);
+    assert.equal(deps1.length, 1);
+
+    const deps2 = detective(fnWithDynamicRequire, { skipLazyLoaded: true });
+    assert.equal(deps2.length, 0);
+  });
+
   describe('es6', () => {
     it('supports es6 syntax', () => {
       const deps = detective('const a = require("./a");\n let b = require("./b");');


### PR DESCRIPTION
# Overview

The [node-detective-amd](https://github.com/dependents/node-detective-amd) module has a `skipLazyLoaded` option that makes it possible to ignore dynamic requires.

This PR adds the same option to this library, making it possible to indicate that something like this is legal:

```
function foo() {
  const doThing = require('./a');
  doThing();
}
```

